### PR TITLE
add structured-data for SEO

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,11 @@ profile:
   email: example@mail.com
   bio: Awesome guy.
 
+# HTTP head tag
+head:
+  structured_data: true
+  favicon: /favicon.ico
+
 # Social media
 # Try to sort by changing the order of the keys
 sns:

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -16,7 +16,11 @@
 <% if (config.feed && config.feed.path) {
 %><link rel="alternate" type="application/rss+xml" title="<%= config.title %>" href="<%= url_for(config.feed.path) %>">
 <% }
-%><%- css('theme.' + theme.themeHash)%>
+%>
+<% if (theme.head.structured_data === true ){ %>
+    <%- partial('structured-data') %>
+<% } %>
+<%- css('theme.' + theme.themeHash)%>
 <%- load_css() %>
 <%- ga() %>
 <%- js('config.' + theme.hash) %>

--- a/layout/structured-data.ejs
+++ b/layout/structured-data.ejs
@@ -1,0 +1,69 @@
+<% if(page.current === 1) { %>
+    <script type="application/ld+json">
+    {
+        "@context": "http://schema.org",
+        "@type": "Website",
+        "publisher": {
+            "@type": "Organization",
+            "name": "<%= config.title %>",
+            "logo": "<%= theme.head.favicon %>"
+        },
+        "url": "<%- config.url %>",
+        "image": {
+            "@type": "ImageObject",
+            "url": "<%= theme.head.favicon %>"
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "<%= config.url %>"
+        },
+        "description": "<%= config.description %>"
+    }
+    </script>
+    <% } %>
+
+        <% if( page.slug ) { %>
+            <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "publisher": {
+            "@type": "Organization",
+            "name": "<%= config.title %>",
+            "logo": {
+                "@type":"ImageObject",
+                "url": "<%= config.url + theme.head.favicon %>"
+            }
+        },
+        "author": {
+            "@type": "Person",
+            "name": "<%= config.author %>",
+            "image": {
+                "@type": "ImageObject",
+                "url": "<%= theme.profile.avatar %>"
+            },
+            "description": "<%- config.description %>"
+        },
+        "url": "<%- config.url + url_for(path).slice(0, -10) %>",
+        "headline": "<%- page.title %>",
+        "name": "<%- page.title %>",
+        "inLanguage": {
+            "@type": "Language",
+            "alternateName": "<%= config.language %>"
+        },
+        "image": {
+            "@type": "ImageObject",
+            "url": "<%= page.thumbnail %>"
+        },
+        "datePublished": "<%= page.date %>",
+        "dateModified": "<%= page.updated %>",
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "<%- config.url + url_for(path).slice(0, -10) %>"
+        },
+    
+        "keywords": "<% if(page.tags && page.tags.each) { page.tags.each(function(tag) { %><%- ',' + tag.name %><% })} %><%= theme.head.keywords %>",
+        "description": "<% if(page.description) { %><%= page.description %><% } else if(page.excerpt){ %><%= strip_html(page.excerpt).replace(/^s*/, '').replace(/s*$/, '') %><% } else if (config.description){ %><%= config.description %><% } %>"
+    }
+    </script>
+<% } %>


### PR DESCRIPTION
For SEO friendly, add structured-data for post article and homepage.

Take my blog as an example.
Home page: https://search.google.com/structured-data/testing-tool/u/0/?hl=zh-CN#url=https%3A%2F%2Fnote.itswincer.com%2F

Post article: https://search.google.com/structured-data/testing-tool/u/0/?hl=zh-CN#url=https%3A%2F%2Fnote.itswincer.com%2Fposts%2Fdbcdebb%2F